### PR TITLE
Pushes sanitize function in the store update

### DIFF
--- a/src/components/Point/Point2d/Point2d.tsx
+++ b/src/components/Point/Point2d/Point2d.tsx
@@ -2,15 +2,14 @@ import React from 'react'
 import styled from '@xstyled/styled-components'
 import { th } from '@xstyled/system'
 import { PointCoordinates } from '../../PointCoordinates'
-import { InternalPoint2dSettings, KEYS } from './point2d-plugin'
+import { InternalPoint2dSettings } from './point2d-plugin'
 import { LevaInputProps } from '../../../types/'
-import { Point2d as Point2dType } from '../../../types/public-api-types'
+import { Point2d as Point2dType, Point2dObject } from '../../../types/public-api-types'
 import { Label, Row } from '../../UI'
 import { Joystick } from './Joystick'
-import { mapArrayToKeys } from '../../../utils'
 import { useInputContext } from '../../../context'
 
-export type Point2dProps = LevaInputProps<Point2dType, InternalPoint2dSettings>
+export type Point2dProps = LevaInputProps<Point2dType, InternalPoint2dSettings, Point2dObject>
 
 export const Container = styled.div`
   display: grid;
@@ -19,14 +18,13 @@ export const Container = styled.div`
 `
 
 export function Point2d() {
-  const { label, value, onUpdate, settings } = useInputContext<Point2dProps>()
-  const _value = mapArrayToKeys(value, KEYS)
+  const { label, displayValue, onUpdate, settings } = useInputContext<Point2dProps>()
   return (
     <Row input>
       <Label>{label}</Label>
       <Container>
-        <Joystick value={_value} settings={settings} onUpdate={onUpdate} />
-        <PointCoordinates value={_value} settings={settings} onUpdate={onUpdate} />
+        <Joystick value={displayValue} settings={settings} onUpdate={onUpdate} />
+        <PointCoordinates value={displayValue} settings={settings} onUpdate={onUpdate} />
       </Container>
     </Row>
   )

--- a/src/components/Point/Point3d/Point3d.tsx
+++ b/src/components/Point/Point3d/Point3d.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import styled from '@xstyled/styled-components'
 import { LevaInputProps } from '../../../types/'
-import { Point3d as Point3dType } from '../../../types/public-api-types'
+import { Point3d as Point3dType, Point3dObject } from '../../../types/public-api-types'
 import { PointCoordinates } from '../../PointCoordinates'
 import { Label, Row } from '../../UI'
-import { KEYS, InternalPoint3dSettings } from './point3d-plugin'
-import { mapArrayToKeys } from '../../../utils'
+import { InternalPoint3dSettings } from './point3d-plugin'
 import { useInputContext } from '../../../context'
 
-type Point3dProps = LevaInputProps<Point3dType, InternalPoint3dSettings>
+type Point3dProps = LevaInputProps<Point3dType, InternalPoint3dSettings, Point3dObject>
 
 const Container = styled.div`
   display: grid;
@@ -17,13 +16,12 @@ const Container = styled.div`
 `
 
 export function Point3d() {
-  const { label, value, onUpdate, settings } = useInputContext<Point3dProps>()
-  const _value = mapArrayToKeys(value, KEYS)
+  const { label, displayValue, onUpdate, settings } = useInputContext<Point3dProps>()
   return (
     <Row input>
       <Label>{label}</Label>
       <Container>
-        <PointCoordinates value={_value} settings={settings} onUpdate={onUpdate} />
+        <PointCoordinates value={displayValue} settings={settings} onUpdate={onUpdate} />
       </Container>
     </Row>
   )

--- a/src/components/PointCoordinates/PointCoordinates.tsx
+++ b/src/components/PointCoordinates/PointCoordinates.tsx
@@ -16,7 +16,7 @@ type CoordinateProps<T extends CoordinateValue> = {
 function Coordinate<T extends CoordinateValue>({ value, valueKey, settings, onUpdate }: CoordinateProps<T>) {
   const args = { type: 'NUMBER', value: value[valueKey], settings }
 
-  const set = (newValue: any) => onUpdate({ ...value, [valueKey]: sanitizeValue({ ...args, newValue }) })
+  const set = (newValue: any) => onUpdate({ ...value, [valueKey]: sanitizeValue(args, newValue) })
 
   const number = useLevaUpdate({ ...args, set })
 

--- a/src/components/PointCoordinates/PointCoordinates.tsx
+++ b/src/components/PointCoordinates/PointCoordinates.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useLevaUpdate } from '../../hooks'
+import { sanitizeValue } from '../../utils'
 import { NumberInner } from '../Number'
 import { InternalNumberSettings } from '../Number/number-plugin'
 
@@ -12,9 +13,12 @@ type CoordinateProps<T extends CoordinateValue> = {
   onUpdate: (value: T) => void
 }
 
-export function Coordinate<T extends CoordinateValue>({ value, valueKey, settings, onUpdate }: CoordinateProps<T>) {
-  const set = (v: number) => onUpdate({ ...value, [valueKey]: v })
-  const number = useLevaUpdate({ type: 'NUMBER', value: value[valueKey], set, settings })
+function Coordinate<T extends CoordinateValue>({ value, valueKey, settings, onUpdate }: CoordinateProps<T>) {
+  const args = { type: 'NUMBER', value: value[valueKey], settings }
+
+  const set = (newValue: any) => onUpdate({ ...value, [valueKey]: sanitizeValue({ ...args, newValue }) })
+
+  const number = useLevaUpdate({ ...args, set })
 
   return (
     <NumberInner

--- a/src/hooks/useDragNumber.ts
+++ b/src/hooks/useDragNumber.ts
@@ -1,18 +1,17 @@
 import { useDrag } from './useDrag'
 import { LevaInputProps } from '../types/'
 import { InternalNumberSettings, sanitizeStep } from '../components/Number/number-plugin'
+import { ceil } from '../utils'
 
 type UseDragNumberProps = {
   settings: InternalNumberSettings
   onDrag: LevaInputProps<number>['onUpdate']
 }
 
-const PRECISION = 100
-
 export function useDragNumber({ settings, onDrag }: UseDragNumberProps) {
   const { step } = settings
-  return useDrag(({ delta: [dx], movement: [, y] }) => {
-    const _step = y < -PRECISION ? 2 * step : y > PRECISION ? step / 2 : step
-    onDrag((v: number) => sanitizeStep(v + Math.round(dx) * _step, settings))
+  return useDrag(({ delta: [dx], shiftKey }) => {
+    const _step = shiftKey ? step : step * 2
+    onDrag((v: number) => sanitizeStep(v + ceil(dx) * _step, settings))
   })
 }

--- a/src/hooks/useLevaUpdate.ts
+++ b/src/hooks/useLevaUpdate.ts
@@ -1,23 +1,10 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Plugins } from '../register'
-import { dequal } from 'dequal'
-
-function sanitize<Settings extends object>(type: string, value: any, settings?: Settings) {
-  const { sanitize } = Plugins[type]
-  if (sanitize) return sanitize(value, settings)
-  return value
-}
 
 function format<Settings extends object>(type: string, value: any, settings?: Settings) {
   const { format } = Plugins[type]
   if (format) return format(value, settings)
   return value
-}
-
-function validate<Settings extends object>(type: string, value: any, settings?: Settings) {
-  const { validate } = Plugins[type]
-  if (validate) return validate(value, settings)
-  return true
 }
 
 type Props<V, Settings> = {
@@ -28,46 +15,23 @@ type Props<V, Settings> = {
 }
 
 export function useLevaUpdate<V, Settings extends object>({ value, type, settings, set }: Props<V, Settings>) {
-  // the last correct registered value
-  const lastCorrectValue = useRef(value)
-
   // the value used by the panel vs the value
   const [displayValue, setDisplayValue] = useState(format(type, value, settings))
   const setFormat = useCallback(v => setDisplayValue(format(type, v, settings)), [type, settings])
 
   const onUpdate = useCallback(
-    (displayValueOrFn: ((v: V) => any) | any) => {
-      const displayValue =
-        typeof displayValueOrFn === 'function' ? displayValueOrFn(lastCorrectValue.current) : displayValueOrFn
-
-      if (!validate(type, displayValue, settings)) {
-        setFormat(lastCorrectValue.current)
-        return
+    (updatedValue: any) => {
+      try {
+        set(updatedValue)
+      } catch (previousValue) {
+        setFormat(previousValue)
       }
-      const newValue = sanitize(type, displayValue, settings)
-
-      /**
-       * @note I had to remove the check as sometimes the sanitized value
-       * doesn't match the input value. For example, if the minimum value of
-       * a number is 30, and the user inputs 15. Then the newValue will be sanitized
-       * to 30 and subsequent calls like 14, 0, etc. won't result in a render.
-       */
-      // if new value is equivalent to previous value do nothing
-      // if (dequal(newValue, lastCorrectValue.current)) return
-
-      lastCorrectValue.current = newValue
-
-      setFormat(newValue)
-      set(newValue)
     },
-    [type, settings, setFormat, set]
+    [setFormat, set]
   )
 
   useEffect(() => {
-    if (!dequal(value, lastCorrectValue.current)) {
-      lastCorrectValue.current = value
-      setFormat(value)
-    }
+    setFormat(value)
   }, [value, setFormat])
 
   return { displayValue, onChange: setDisplayValue, onUpdate }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import create from 'zustand'
 import shallow from 'zustand/shallow'
-import { normalizeInput, pick, getKeyPath, join } from './utils'
+import { normalizeInput, pick, getKeyPath, join, updateInput } from './utils'
 import { warn, LevaErrors } from './utils/log'
 import { Data, FolderSettings, SpecialInputTypes } from './types/'
 
@@ -59,7 +59,7 @@ function setValueAtPath(path: string, value: any) {
   _store.setState(s => {
     const data = s.data
     //@ts-expect-error (we always update inputs with a value)
-    data[path].value = value
+    updateInput(data[path], value)
     return { data }
   })
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,9 +47,9 @@ export type Tree = {
   [key: string]: { __levaInput: true; valueKey: string; path: string } | Tree
 }
 
-export type LevaInputProps<V, InternalSettings = {}> = {
+export type LevaInputProps<V, InternalSettings = {}, DisplayValue = any> = {
   label: string
-  displayValue: any
+  displayValue: DisplayValue
   value: V
   onChange: React.Dispatch<any>
   onUpdate: (v: any | ((_v: any) => any)) => void

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -32,17 +32,16 @@ function validate<Settings extends object>(type: string, value: any, settings?: 
 
 export function updateInput(input: DataInput, newValue: any) {
   const { value, type, settings } = input
-  input.value = sanitizeValue({ type, value, newValue, settings })
+  input.value = sanitizeValue({ type, value, settings }, newValue)
 }
 
 type SanitizeProps = {
   type: string
   value: any
-  newValue: any
   settings: object | undefined
 }
 
-export function sanitizeValue({ type, value, newValue, settings }: SanitizeProps) {
+export function sanitizeValue({ type, value, settings }: SanitizeProps, newValue: any) {
   const _newValue = typeof newValue === 'function' ? newValue(value) : newValue
 
   if (!validate(type, _newValue, settings)) {

--- a/src/utils/input.ts
+++ b/src/utils/input.ts
@@ -1,4 +1,5 @@
-import { normalize, getValueType } from '../register'
+import { normalize, getValueType, Plugins } from '../register'
+import { DataInput } from '../types'
 import { warn, LevaErrors } from './log'
 
 // returns a value in the form of { value, settings}
@@ -16,3 +17,48 @@ export function normalizeInput(input: any, path: string) {
 }
 
 export const isInput = (v: object) => '__levaInput' in v
+
+function sanitize<Settings extends object>(type: string, value: any, settings?: Settings) {
+  const { sanitize } = Plugins[type]
+  if (sanitize) return sanitize(value, settings)
+  return value
+}
+
+function validate<Settings extends object>(type: string, value: any, settings?: Settings) {
+  const { validate } = Plugins[type]
+  if (validate) return validate(value, settings)
+  return true
+}
+
+export function updateInput(input: DataInput, newValue: any) {
+  const { value, type, settings } = input
+  input.value = sanitizeValue({ type, value, newValue, settings })
+}
+
+type SanitizeProps = {
+  type: string
+  value: any
+  newValue: any
+  settings: object | undefined
+}
+
+export function sanitizeValue({ type, value, newValue, settings }: SanitizeProps) {
+  const _newValue = typeof newValue === 'function' ? newValue(value) : newValue
+
+  if (!validate(type, _newValue, settings)) {
+    throw value
+  }
+  const sanitizedNewValue = sanitize(type, _newValue, settings)
+
+  if (sanitizedNewValue === value) {
+    /**
+     * @note This makes the update function throw when the new value is the same
+     * as the previous one. This can happen for example, if the minimum value of
+     * a number is 30, and the user inputs 15. Then the newValue will be sanitized
+     * to 30 and subsequent calls like 14, 0, etc. won't result in the component displaying
+     * the value to be notified (ie there wouldn't be a new render)
+     */
+    throw value
+  }
+  return sanitizedNewValue
+}

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,6 +1,6 @@
 export const clamp = (x: number, min: number, max: number) => (x > max ? max : x < min ? min : x)
-export const floor = (min: number, x: number) => Math.max(min, Math.floor(x))
 export const pad = (x: number, pad: number) => String(x).padStart(pad, '0')
+export const ceil = (v: number) => Math.sign(v) * Math.ceil(Math.abs(v))
 
 const log10 = Math.log(10)
 


### PR DESCRIPTION
This should make it easier for future updates where we might want to update the value from an external interface.

### Before this PR

The component from the control pane was responsible for sanitizing the value before updating it to the store. This was working fine but we if we ever wanted to let the user update the store outside of the component, we would have had to trust the user that he reimplemented the logic for validating and sanitizing the updated value on its own.

### After this PR

When a value is updated, the store is now responsible for validating and sanitizing the updated value. If the value is incorrect it will throw. If the value if the same as the previous one, it will trow.

> When the minimum value of a number input is 30, and the user inputs "15". Then the newValue will be sanitized to 30 and the input field displayed value will be reverted to "30" **only if the previous value wasn't already 30!**. Therefore we need to throw so that the component knows it needs to update its input displayedValue.