### PR TITLE
feat: expose store via exports

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useControls, folder, button, monitor, Leva } from 'leva'
+import { useControls, folder, button, monitor, Leva, store } from 'leva'
 import { Noise } from 'noisejs'
 import Scene3D from './Scene3D'
 import { greenOrBlue } from './myPlugin'
@@ -93,10 +93,14 @@ export default function App() {
   const [c1, setC1] = React.useState(true)
   const [c2, setC2] = React.useState(false)
   // useControls({ checkbox: true })
+
+  useControls('test', { myTest: 1 })
+  
   return (
     <>
       <Leva />
       <div style={{ display: 'flex' }}>
+        <input type="text" onChange={(e) => store.setValueAtPath('test.myTest', e.target.value)}></input>
         <div style={{ width: '50%' }}>{c2 && <Scene3D />}</div>
         <div>
           {c1 && <Comp1 />}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { createPlugin } from './plugins'
 export { Leva } from './Leva'
 export { useInputContext } from './context'
 
+export * from './store'
 export * from './useControls'
 export * from './helpers/'
 export * from './components/UI'

--- a/src/store.ts
+++ b/src/store.ts
@@ -58,6 +58,7 @@ function setData(newData: Data) {
 function setValueAtPath(path: string, value: any) {
   _store.setState(s => {
     const data = s.data
+    console.log(data, value)
     //@ts-expect-error (we always update inputs with a value)
     updateInput(data[path], value)
     return { data }

--- a/src/store.ts
+++ b/src/store.ts
@@ -58,7 +58,6 @@ function setData(newData: Data) {
 function setValueAtPath(path: string, value: any) {
   _store.setState(s => {
     const data = s.data
-    console.log(data, value)
     //@ts-expect-error (we always update inputs with a value)
     updateInput(data[path], value)
     return { data }


### PR DESCRIPTION
- [ ] instead of exposing the whole store, just export `setValueAtPath`
- [ ] create an accessor `getValueAtPath` 