### PR TITLE
Schema support keys

### DIFF
--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -195,7 +195,7 @@ type SchemaItemWithOptions =
   | (SpecialInput & GenericSchemaItemOptions)
   | FolderInput<unknown>
 
-export type Schema = Record<string, SchemaItemWithOptions>
+export type Schema<K = string> = Record<K, SchemaItemWithOptions>
 
 /**
  * Dummy type used internally to flag non compatible input types.


### PR DESCRIPTION
Hello!

I would like to limit the keys of Schema.

The usage would be like this:
``` ts
type Keys = 'level' | 'players' | 'paused'
type CustomSchema = Schema<Keys>
```

And if no keys are given, it works like it does currently
``` ts
type CustomSchema = Schema
```