### PR TITLE
Fix React 18 and Radix UI TooltipProvider errors in demos

### DIFF
--- a/demo/src/index.jsx
+++ b/demo/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-advanced-panels/src/index.jsx
+++ b/demo/src/sandboxes/leva-advanced-panels/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-busy/src/index.tsx
+++ b/demo/src/sandboxes/leva-busy/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-custom-plugin/src/index.tsx
+++ b/demo/src/sandboxes/leva-custom-plugin/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-minimal/src/index.jsx
+++ b/demo/src/sandboxes/leva-minimal/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-plugin-bezier/src/index.tsx
+++ b/demo/src/sandboxes/leva-plugin-bezier/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-plugin-dates/src/index.tsx
+++ b/demo/src/sandboxes/leva-plugin-dates/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-plugin-plot/src/index.tsx
+++ b/demo/src/sandboxes/leva-plugin-plot/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-plugin-spring/src/index.tsx
+++ b/demo/src/sandboxes/leva-plugin-spring/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-scroll/src/index.jsx
+++ b/demo/src/sandboxes/leva-scroll/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-theme/src/index.jsx
+++ b/demo/src/sandboxes/leva-theme/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-transient/src/index.jsx
+++ b/demo/src/sandboxes/leva-transient/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/demo/src/sandboxes/leva-ui/src/index.jsx
+++ b/demo/src/sandboxes/leva-ui/src/index.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
 import './index.css'
 
 const rootElement = document.getElementById('root')
-ReactDOM.render(
+const root = createRoot(rootElement)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  rootElement
+  </React.StrictMode>
 )

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react'
+import * as RadixTooltip from '@radix-ui/react-tooltip'
 import { buildTree } from './tree'
 import { TreeWrapper } from '../Folder'
 
@@ -177,39 +178,41 @@ const LevaCore = React.memo(
     globalStyles()
 
     return (
-      <PanelSettingsContext.Provider value={{ hideCopyButton }}>
-        <StyledRoot
-          ref={rootRef}
-          className={rootClass}
-          fill={fill}
-          flat={flat}
-          oneLineLabels={oneLineLabels}
-          hideTitleBar={!titleBar}
-          style={{ display: shouldShow ? 'block' : 'none' }}>
-          {titleBar && (
-            <TitleWithFilter
-              onDrag={(point) => {
-                set(point)
-                onDrag?.(point)
-              }}
-              onDragStart={(point) => onDragStart?.(point)}
-              onDragEnd={(point) => onDragEnd?.(point)}
-              setFilter={setFilter}
-              toggle={(flag?: boolean) => setToggle((t) => flag ?? !t)}
-              toggled={toggled}
-              title={title}
-              drag={drag}
-              filterEnabled={filterEnabled}
-              from={position}
-            />
-          )}
-          {shouldShow && (
-            <StoreContext.Provider value={store}>
-              <TreeWrapper isRoot fill={fill} flat={flat} tree={tree} toggled={toggled} />
-            </StoreContext.Provider>
-          )}
-        </StyledRoot>
-      </PanelSettingsContext.Provider>
+      <RadixTooltip.Provider>
+        <PanelSettingsContext.Provider value={{ hideCopyButton }}>
+          <StyledRoot
+            ref={rootRef}
+            className={rootClass}
+            fill={fill}
+            flat={flat}
+            oneLineLabels={oneLineLabels}
+            hideTitleBar={!titleBar}
+            style={{ display: shouldShow ? 'block' : 'none' }}>
+            {titleBar && (
+              <TitleWithFilter
+                onDrag={(point) => {
+                  set(point)
+                  onDrag?.(point)
+                }}
+                onDragStart={(point) => onDragStart?.(point)}
+                onDragEnd={(point) => onDragEnd?.(point)}
+                setFilter={setFilter}
+                toggle={(flag?: boolean) => setToggle((t) => flag ?? !t)}
+                toggled={toggled}
+                title={title}
+                drag={drag}
+                filterEnabled={filterEnabled}
+                from={position}
+              />
+            )}
+            {shouldShow && (
+              <StoreContext.Provider value={store}>
+                <TreeWrapper isRoot fill={fill} flat={flat} tree={tree} toggled={toggled} />
+              </StoreContext.Provider>
+            )}
+          </StyledRoot>
+        </PanelSettingsContext.Provider>
+      </RadixTooltip.Provider>
     )
   }
 )


### PR DESCRIPTION
- Migrate all 13 demo entry files from ReactDOM.render() to createRoot() API
- Add TooltipProvider wrapper to LevaRoot component to fix Radix UI tooltip errors

Changes:
- Updated demo/src/index.jsx and all sandbox demo index files to use React 18's createRoot API
- Imported and wrapped LevaRoot with RadixTooltip.Provider to satisfy Radix UI requirements
- This resolves console warnings and errors when running demos