### PR TITLE
feat: add `noCache` option to clear cached values

### DIFF
--- a/.changeset/clear-path-on-unmount.md
+++ b/.changeset/clear-path-on-unmount.md
@@ -2,7 +2,8 @@
 "leva": minor
 ---
 
-Add `clearOnUnmount` option to remove inputs from the store when their component unmounts.
+Add `clearOnUnmount` option and `store.clearPath` to remove inputs from the store when their component unmounts.
 
+- `store.clearPath(path)` — new method to imperatively remove a single input from the store.
 - `InputOptions.clearOnUnmount` — per-input flag; when `true` the input is removed from the store on unmount.
 - `LevaRootProps.clearOnUnmount` — panel-level flag; when `true` all inputs managed by that panel are cleared on unmount, overriding the per-input setting.

--- a/.changeset/clear-path-on-unmount.md
+++ b/.changeset/clear-path-on-unmount.md
@@ -2,8 +2,8 @@
 "leva": minor
 ---
 
-Add `clearOnUnmount` option and `store.clearPath` to remove inputs from the store when their component unmounts.
+Add `clearOnUnmount` option and `store.clearPath` to discard cached input values when they are no longer in use.
 
-- `store.clearPath(path)` — new method to imperatively remove a single input from the store.
-- `InputOptions.clearOnUnmount` — per-input flag; when `true` the input is removed from the store on unmount.
-- `LevaRootProps.clearOnUnmount` — panel-level flag; when `true` all inputs managed by that panel are cleared on unmount, overriding the per-input setting.
+- `store.clearPath(path)` — new method to imperatively discard the cached value of an input that is no longer mounted.
+- `InputOptions.clearOnUnmount` — per-input flag; when `true` the input's cached value is discarded from the store on unmount.
+- `LevaRootProps.clearOnUnmount` — panel-level flag; when `true` all inputs managed by that panel have their cached values discarded on unmount, overriding the per-input setting.

--- a/.changeset/clear-path-on-unmount.md
+++ b/.changeset/clear-path-on-unmount.md
@@ -2,8 +2,8 @@
 "leva": minor
 ---
 
-Add `clearOnUnmount` option and `store.clearPath` to discard cached input values when they are no longer in use.
+Add `noCache` option and `store.clearPath` to discard cached input values when they are no longer in use.
 
 - `store.clearPath(path)` — new method to imperatively discard the cached value of an input that is no longer mounted.
-- `InputOptions.clearOnUnmount` — per-input flag; when `true` the input's cached value is discarded from the store on unmount.
-- `LevaRootProps.clearOnUnmount` — panel-level flag; when `true` all inputs managed by that panel have their cached values discarded on unmount, overriding the per-input setting.
+- `InputOptions.noCache` — per-input flag; when `true` the input's cached value is discarded from the store on unmount.
+- `LevaRootProps.noCache` — panel-level flag; when `true` all inputs managed by that panel have their cached values discarded on unmount, overriding the per-input setting.

--- a/.changeset/clear-path-on-unmount.md
+++ b/.changeset/clear-path-on-unmount.md
@@ -1,0 +1,8 @@
+---
+"leva": minor
+---
+
+Add `clearOnUnmount` option to remove inputs from the store when their component unmounts.
+
+- `InputOptions.clearOnUnmount` — per-input flag; when `true` the input is removed from the store on unmount.
+- `LevaRootProps.clearOnUnmount` — panel-level flag; when `true` all inputs managed by that panel are cleared on unmount, overriding the per-input setting.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         id: pnpm-build-cache
         with:
           path: packages/**/dist
-          key: ${{ runner.os }}-pnpm-build-${{ hashFiles('/packages/**/*') }}
+          key: ${{ runner.os }}-pnpm-build-${{ hashFiles('packages/**/*.ts', 'packages/**/*.tsx') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-build-
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -32,7 +32,7 @@ export default function MyApp() {
           position: { x: 0, y: 0 }, // Initial position (when drag is enabled)
           onDrag: (position) => {}, // Callback when dragged
         }}
-        clearOnUnmount // default = false, discards cached input values when inputs unmount
+        noCache // default = false, discards cached input values when inputs unmount
       />
     </>
   )
@@ -50,7 +50,7 @@ export default function MyApp() {
 - `hidden`: Hides the GUI completely
 - `neverHide`: Keeps GUI visible even when no controls are mounted
 - `hideCopyButton`: Hides the copy button in the title bar
-- `clearOnUnmount`: When `true`, all inputs managed by this panel discard their cached values when they unmount (overrides the per-input `clearOnUnmount` setting)
+- `noCache`: When `true`, all inputs managed by this panel discard their cached values when they unmount (overrides the per-input `noCache` setting)
 - `titleBar`: Object with title bar configuration:
   - `title`: Custom title string
   - `drag`: Enable/disable dragging
@@ -107,17 +107,17 @@ export default function MyApp() {
 
 By default Leva caches input values so they survive unmount/remount cycles. You can opt out of this behaviour at two levels:
 
-**Panel-level** — pass `clearOnUnmount` to `<Leva>` (or `<LevaPanel>`). Every input managed by that panel will discard its cached value when its component unmounts. This takes priority over the per-input setting.
+**Panel-level** — pass `noCache` to `<Leva>` (or `<LevaPanel>`). Every input managed by that panel will discard its cached value when its component unmounts. This takes priority over the per-input setting.
 
 ```jsx
-<Leva clearOnUnmount />
+<Leva noCache />
 ```
 
-**Per-input** — set `clearOnUnmount: true` inside the schema for individual inputs (see [Input Options](inputs.md#clearonunmount)).
+**Per-input** — set `noCache: true` inside the schema for individual inputs (see [Input Options](inputs.md#nocache)).
 
 ```jsx
 useControls({
-  sessionValue: { value: 0, clearOnUnmount: true },
+  sessionValue: { value: 0, noCache: true },
   persistentValue: { value: 0 },
 })
 ```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -32,6 +32,7 @@ export default function MyApp() {
           position: { x: 0, y: 0 }, // Initial position (when drag is enabled)
           onDrag: (position) => {}, // Callback when dragged
         }}
+        clearOnUnmount // default = false, discards cached input values when inputs unmount
       />
     </>
   )
@@ -49,6 +50,7 @@ export default function MyApp() {
 - `hidden`: Hides the GUI completely
 - `neverHide`: Keeps GUI visible even when no controls are mounted
 - `hideCopyButton`: Hides the copy button in the title bar
+- `clearOnUnmount`: When `true`, all inputs managed by this panel discard their cached values when they unmount (overrides the per-input `clearOnUnmount` setting)
 - `titleBar`: Object with title bar configuration:
   - `title`: Custom title string
   - `drag`: Enable/disable dragging
@@ -98,6 +100,37 @@ export default function MyApp() {
       <Leva hidden={true} />
     </>
   )
+}
+```
+
+### Clearing Cached Values on Unmount
+
+By default Leva caches input values so they survive unmount/remount cycles. You can opt out of this behaviour at two levels:
+
+**Panel-level** — pass `clearOnUnmount` to `<Leva>` (or `<LevaPanel>`). Every input managed by that panel will discard its cached value when its component unmounts. This takes priority over the per-input setting.
+
+```jsx
+<Leva clearOnUnmount />
+```
+
+**Per-input** — set `clearOnUnmount: true` inside the schema for individual inputs (see [Input Options](inputs.md#clearonunmount)).
+
+```jsx
+useControls({
+  sessionValue: { value: 0, clearOnUnmount: true },
+  persistentValue: { value: 0 },
+})
+```
+
+**Imperative** — call `store.clearPath(path)` to discard the cached value of a single input at any time without unmounting it:
+
+```jsx
+import { levaStore, useControls } from 'leva'
+
+function MyComponent() {
+  const { position } = useControls({ position: { x: 0, y: 0 } })
+
+  return <button onClick={() => levaStore.clearPath('position')}>Reset position cache</button>
 }
 ```
 

--- a/docs/getting-started/inputs.md
+++ b/docs/getting-started/inputs.md
@@ -381,18 +381,18 @@ const values = useControls({
 })
 ```
 
-### clearOnUnmount
+### noCache
 
-By default, Leva caches input values so they persist across unmount/remount cycles. Set `clearOnUnmount: true` on a specific input to discard its cached value when its component unmounts, so the next mount starts fresh from the initial value:
+By default, Leva caches input values so they persist across unmount/remount cycles. Set `noCache: true` on a specific input to discard its cached value when its component unmounts, so the next mount starts fresh from the initial value:
 
 ```jsx
 const { sessionValue, persistentValue } = useControls({
-  sessionValue: { value: 0, clearOnUnmount: true },
+  sessionValue: { value: 0, noCache: true },
   persistentValue: { value: 0 },
 })
 ```
 
-See also the panel-level [`clearOnUnmount`](configuration.md#clearonunmount) option to apply this behaviour to all inputs at once.
+See also the panel-level [`noCache`](configuration.md#nocache) option to apply this behaviour to all inputs at once.
 
 ### Enforcing Input Type
 

--- a/docs/getting-started/inputs.md
+++ b/docs/getting-started/inputs.md
@@ -381,6 +381,19 @@ const values = useControls({
 })
 ```
 
+### clearOnUnmount
+
+By default, Leva caches input values so they persist across unmount/remount cycles. Set `clearOnUnmount: true` on a specific input to discard its cached value when its component unmounts, so the next mount starts fresh from the initial value:
+
+```jsx
+const { sessionValue, persistentValue } = useControls({
+  sessionValue: { value: 0, clearOnUnmount: true },
+  persistentValue: { value: 0 },
+})
+```
+
+See also the panel-level [`clearOnUnmount`](configuration.md#clearonunmount) option to apply this behaviour to all inputs at once.
+
 ### Enforcing Input Type
 
 Force a specific input type even if Leva would infer differently:

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -92,9 +92,9 @@ export type LevaRootProps = {
   hideCopyButton?: boolean
   /**
    * If true, all inputs will be cleared from the store when their component unmounts,
-   * regardless of the per-input clearOnUnmount setting.
+   * regardless of the per-input noCache setting.
    */
-  clearOnUnmount?: boolean
+  noCache?: boolean
 }
 
 export function LevaRoot({
@@ -102,17 +102,17 @@ export function LevaRoot({
   hidden = false,
   theme,
   collapsed = false,
-  clearOnUnmount = false,
+  noCache = false,
   ...props
 }: LevaRootProps) {
   const themeContext = useDeepMemo(() => mergeTheme(theme), [theme])
 
   useEffect(() => {
     if (store) {
-      store.setClearOnUnmount(clearOnUnmount)
-      return () => store.setClearOnUnmount(false)
+      store.setNoCache(noCache)
+      return () => store.setNoCache(false)
     }
-  }, [store, clearOnUnmount])
+  }, [store, noCache])
 
   // collapsible
   const [toggled, setToggle] = useState(!collapsed)

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -97,7 +97,14 @@ export type LevaRootProps = {
   clearOnUnmount?: boolean
 }
 
-export function LevaRoot({ store, hidden = false, theme, collapsed = false, clearOnUnmount = false, ...props }: LevaRootProps) {
+export function LevaRoot({
+  store,
+  hidden = false,
+  theme,
+  collapsed = false,
+  clearOnUnmount = false,
+  ...props
+}: LevaRootProps) {
   const themeContext = useDeepMemo(() => mergeTheme(theme), [theme])
 
   useEffect(() => {

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -108,7 +108,10 @@ export function LevaRoot({
   const themeContext = useDeepMemo(() => mergeTheme(theme), [theme])
 
   useEffect(() => {
-    if (store) store.setClearOnUnmount(clearOnUnmount)
+    if (store) {
+      store.setClearOnUnmount(clearOnUnmount)
+      return () => store.setClearOnUnmount(false)
+    }
   }, [store, clearOnUnmount])
 
   // collapsible

--- a/packages/leva/src/components/Leva/LevaRoot.tsx
+++ b/packages/leva/src/components/Leva/LevaRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import * as RadixTooltip from '@radix-ui/react-tooltip'
 import { buildTree } from './tree'
 import { TreeWrapper } from '../Folder'
@@ -90,10 +90,20 @@ export type LevaRootProps = {
    * If true, the copy button will be hidden
    */
   hideCopyButton?: boolean
+  /**
+   * If true, all inputs will be cleared from the store when their component unmounts,
+   * regardless of the per-input clearOnUnmount setting.
+   */
+  clearOnUnmount?: boolean
 }
 
-export function LevaRoot({ store, hidden = false, theme, collapsed = false, ...props }: LevaRootProps) {
+export function LevaRoot({ store, hidden = false, theme, collapsed = false, clearOnUnmount = false, ...props }: LevaRootProps) {
   const themeContext = useDeepMemo(() => mergeTheme(theme), [theme])
+
+  useEffect(() => {
+    if (store) store.setClearOnUnmount(clearOnUnmount)
+  }, [store, clearOnUnmount])
+
   // collapsible
   const [toggled, setToggle] = useState(!collapsed)
 

--- a/packages/leva/src/plugin/index.ts
+++ b/packages/leva/src/plugin/index.ts
@@ -44,6 +44,5 @@ export { styled, keyframes, useTh } from '../styles'
 
 // export types
 export * from '../types/public'
-export type { StoreType, Data } from '../types/internal'
 export type { InternalVectorSettings } from '../plugins/Vector/vector-types'
 export type { InternalNumberSettings } from '../plugins/Number/number-types'

--- a/packages/leva/src/plugin/index.ts
+++ b/packages/leva/src/plugin/index.ts
@@ -44,5 +44,6 @@ export { styled, keyframes, useTh } from '../styles'
 
 // export types
 export * from '../types/public'
+export type { StoreType, Data } from '../types/internal'
 export type { InternalVectorSettings } from '../plugins/Vector/vector-types'
 export type { InternalNumberSettings } from '../plugins/Number/number-types'

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -114,6 +114,14 @@ export const Store = function (this: StoreType) {
     })
   }
 
+  this.clearPath = (path) => {
+    store.setState((s) => {
+      const data = { ...s.data }
+      delete data[path]
+      return { data }
+    })
+  }
+
   this.getFolderSettings = (path) => {
     return folders[path] || {}
   }

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -13,9 +13,9 @@ export const Store = function (this: StoreType) {
 
   this.storeId = getUid()
   this.useStore = store
-  this.clearOnUnmount = false
-  this.setClearOnUnmount = (flag) => {
-    this.clearOnUnmount = flag
+  this.noCache = false
+  this.setNoCache = (flag) => {
+    this.noCache = flag
   }
   /**
    * Folders will hold the folder settings for the pane.

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -116,6 +116,8 @@ export const Store = function (this: StoreType) {
 
   this.clearPath = (path) => {
     store.setState((s) => {
+      const input = s.data[path]
+      if (!input || input.__refCount > 0) return s
       const data = { ...s.data }
       delete data[path]
       return { data }

--- a/packages/leva/src/store.ts
+++ b/packages/leva/src/store.ts
@@ -13,6 +13,10 @@ export const Store = function (this: StoreType) {
 
   this.storeId = getUid()
   this.useStore = store
+  this.clearOnUnmount = false
+  this.setClearOnUnmount = (flag) => {
+    this.clearOnUnmount = flag
+  }
   /**
    * Folders will hold the folder settings for the pane.
    * @note possibly make this reactive

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -20,7 +20,7 @@ export type MappedPaths = Record<
     onEditStart?: (...args: any) => void
     onEditEnd?: (...args: any) => void
     transient: boolean
-    clearOnUnmount: boolean
+    noCache: boolean
   }
 >
 
@@ -29,8 +29,8 @@ type Dispose = () => void
 export type StoreType = {
   useStore: UseBoundStore<StoreApi<State>> & SubscribeWithSelectorAPI<State>
   storeId: string
-  clearOnUnmount: boolean
-  setClearOnUnmount: (flag: boolean) => void
+  noCache: boolean
+  setNoCache: (flag: boolean) => void
   orderPaths: (paths: string[]) => string[]
   setOrderedPaths: (newPaths: string[]) => void
   disposePaths: (paths: string[]) => void

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -29,6 +29,8 @@ type Dispose = () => void
 export type StoreType = {
   useStore: UseBoundStore<StoreApi<State>> & SubscribeWithSelectorAPI<State>
   storeId: string
+  clearOnUnmount: boolean
+  setClearOnUnmount: (flag: boolean) => void
   orderPaths: (paths: string[]) => string[]
   setOrderedPaths: (newPaths: string[]) => void
   disposePaths: (paths: string[]) => void

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -32,6 +32,7 @@ export type StoreType = {
   setOrderedPaths: (newPaths: string[]) => void
   disposePaths: (paths: string[]) => void
   dispose: () => void
+  clearPath: (path: string) => void
   getVisiblePaths: () => string[]
   getFolderSettings: (path: string) => FolderSettings
   getData: () => Data

--- a/packages/leva/src/types/internal.ts
+++ b/packages/leva/src/types/internal.ts
@@ -20,6 +20,7 @@ export type MappedPaths = Record<
     onEditStart?: (...args: any) => void
     onEditEnd?: (...args: any) => void
     transient: boolean
+    clearOnUnmount: boolean
   }
 >
 

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -185,6 +185,7 @@ export type InputOptions = GenericSchemaItemOptions &
     disabled?: boolean
     onEditStart?: (value: any, path: string, context: OnHandlerContext) => void
     onEditEnd?: (value: any, path: string, context: OnHandlerContext) => void
+    clearOnUnmount?: boolean
   }
 
 type SchemaItemWithOptions =

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -185,7 +185,7 @@ export type InputOptions = GenericSchemaItemOptions &
     disabled?: boolean
     onEditStart?: (value: any, path: string, context: OnHandlerContext) => void
     onEditEnd?: (value: any, path: string, context: OnHandlerContext) => void
-    clearOnUnmount?: boolean
+    noCache?: boolean
   }
 
 type SchemaItemWithOptions =

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import { useControls } from './useControls'
 import { levaStore } from './store'
+import { LevaPanel } from './components/Leva'
 
 // Mock stitches to avoid CSS-in-JS insertRule errors in jsdom.
 // @stitches/react is imported transitively via useControls -> components/Leva -> stitches.config.ts.
@@ -145,6 +146,29 @@ describe('useControls mount/unmount lifecycle', () => {
 
     const { getByTestId: getByTestId2 } = render(<NumberComponent id="value2" />)
     expect(getByTestId2('value2').textContent).toBe('5')
+  })
+
+  it('LevaPanel clearOnUnmount prop wires to store and resets inputs on remount', () => {
+    // LevaPanel and the consuming component are rendered in separate trees so
+    // that unmounting the component doesn't also unmount LevaPanel (which would
+    // trigger the cleanup that resets clearOnUnmount to false before the
+    // component's own cleanup can call clearPath).
+    const { unmount: unmountPanel } = render(<LevaPanel store={levaStore} clearOnUnmount />)
+
+    const { getByTestId, unmount: unmountComponent } = render(<NumberComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    act(() => unmountComponent())
+
+    const { getByTestId: getByTestId2 } = render(<NumberComponent id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+
+    unmountPanel()
   })
 
   it('resets to the initial value when remounted after clearPath', () => {

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Integration tests for useControls with store lifecycle
+ */
+
+// Mock stitches to avoid CSS-in-JS insertRule errors in jsdom.
+// @stitches/react is imported transitively via useControls -> components/Leva -> stitches.config.ts.
+// The mock is scoped to this file and doesn't affect production code.
+vi.mock('@stitches/react', () => ({
+  createStitches: () => ({
+    styled: () => () => null,
+    css: () => () => '',
+    globalCss: () => () => {},
+    keyframes: () => '',
+    getCssText: () => '',
+    theme: {},
+    createTheme: () => ({}),
+    config: {},
+  }),
+}))
+
+import React from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useControls } from './useControls'
+import { levaStore } from './store'
+
+afterEach(() => {
+  levaStore.dispose()
+})
+
+function NumberComponent({ id }: { id?: string }) {
+  const { myNumber } = useControls({ myNumber: 5 }, { headless: true })
+  return <div data-testid={id ?? 'value'}>{myNumber}</div>
+}
+
+describe('useControls mount/unmount lifecycle', () => {
+  it('resets to the initial value when remounted after clearPath', async () => {
+    // Mount the component
+    const { getByTestId, unmount } = render(<NumberComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    // Simulate a value change via the store (as if the user dragged the slider)
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    // Unmount – disposePaths decrements __refCount to 0 but the value stays in the store
+    unmount()
+
+    // Clear the cached value so the next mount starts fresh
+    levaStore.clearPath('myNumber')
+
+    // Remount – useControls reads from the schema (value: 5) because the path is gone
+    const { getByTestId: getByTestId2 } = render(<NumberComponent id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+  })
+})

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -2,9 +2,16 @@
  * Integration tests for useControls with store lifecycle
  */
 
+import React, { useEffect } from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useControls } from './useControls'
+import { levaStore } from './store'
+
 // Mock stitches to avoid CSS-in-JS insertRule errors in jsdom.
 // @stitches/react is imported transitively via useControls -> components/Leva -> stitches.config.ts.
 // The mock is scoped to this file and doesn't affect production code.
+// NOTE: vi.mock is hoisted by Vitest's transformer at build time, so this runs before imports regardless of position.
 vi.mock('@stitches/react', () => ({
   createStitches: () => ({
     styled: () => () => null,
@@ -17,12 +24,6 @@ vi.mock('@stitches/react', () => ({
     config: {},
   }),
 }))
-
-import React, { useEffect } from 'react'
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, act } from '@testing-library/react'
-import { useControls } from './useControls'
-import { levaStore } from './store'
 
 afterEach(() => {
   levaStore.dispose()

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -41,7 +41,12 @@ function NestedNumberComponent({ id }: { id?: string }) {
 
 function NumberComponentClearOnUnmount({ id }: { id?: string }) {
   const { myNumber } = useControls({ myNumber: 5 }, { headless: true })
-  useEffect(() => () => { levaStore.clearPath('myNumber') }, [])
+  useEffect(
+    () => () => {
+      levaStore.clearPath('myNumber')
+    },
+    []
+  )
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -33,7 +33,42 @@ function NumberComponent({ id }: { id?: string }) {
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 
+function NestedNumberComponent({ id }: { id?: string }) {
+  const { myNumber } = useControls('myFolder', { myNumber: 5 }, { store: levaStore, headless: true })
+  return <div data-testid={id ?? 'value'}>{myNumber}</div>
+}
+
 describe('useControls mount/unmount lifecycle', () => {
+  it('does not clear a path that is still mounted', () => {
+    const { unmount } = render(<NumberComponent id="value" />)
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+
+    // clearPath is a no-op while the component is still mounted (__refCount > 0)
+    levaStore.clearPath('myNumber')
+    expect(levaStore.get('myNumber')).toBe(42)
+
+    unmount()
+  })
+
+  it('works with nested folder paths', async () => {
+    const { getByTestId, unmount } = render(<NestedNumberComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    act(() => {
+      levaStore.setValueAtPath('myFolder.myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    unmount()
+    levaStore.clearPath('myFolder.myNumber')
+
+    const { getByTestId: getByTestId2 } = render(<NestedNumberComponent id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+  })
+
   it('resets to the initial value when remounted after clearPath', async () => {
     // Mount the component
     const { getByTestId, unmount } = render(<NumberComponent id="value" />)

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@stitches/react', () => ({
   }),
 }))
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import { useControls } from './useControls'
@@ -38,6 +38,17 @@ function NestedNumberComponent({ id }: { id?: string }) {
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 
+function NumberComponentClearOnUnmount({ id }: { id?: string }) {
+  const { myNumber } = useControls({ myNumber: 5 }, { headless: true })
+  useEffect(() => () => { levaStore.clearPath('myNumber') }, [])
+  return <div data-testid={id ?? 'value'}>{myNumber}</div>
+}
+
+function ClearOnUnmountOptionComponent({ id }: { id?: string }) {
+  const { myNumber } = useControls({ myNumber: { value: 5, clearOnUnmount: true } }, { headless: true })
+  return <div data-testid={id ?? 'value'}>{myNumber}</div>
+}
+
 describe('useControls mount/unmount lifecycle', () => {
   it('does not clear a path that is still mounted', () => {
     const { unmount } = render(<NumberComponent id="value" />)
@@ -53,7 +64,7 @@ describe('useControls mount/unmount lifecycle', () => {
     unmount()
   })
 
-  it('works with nested folder paths', async () => {
+  it('works with nested folder paths', () => {
     const { getByTestId, unmount } = render(<NestedNumberComponent id="value" />)
     expect(getByTestId('value').textContent).toBe('5')
 
@@ -69,24 +80,61 @@ describe('useControls mount/unmount lifecycle', () => {
     expect(getByTestId2('value2').textContent).toBe('5')
   })
 
-  it('resets to the initial value when remounted after clearPath', async () => {
-    // Mount the component
-    const { getByTestId, unmount } = render(<NumberComponent id="value" />)
+  it('preserves the value on remount when not cleared', () => {
+    const { unmount } = render(<NumberComponent id="value" />)
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+
+    act(() => unmount())
+
+    // value survives unmount without clearing
+    expect(levaStore.get('myNumber')).toBe(42)
+  })
+
+  it('useEffect clearPath resets the value on remount', () => {
+    const { getByTestId, unmount } = render(<NumberComponentClearOnUnmount id="value" />)
     expect(getByTestId('value').textContent).toBe('5')
 
-    // Simulate a value change via the store (as if the user dragged the slider)
     act(() => {
       levaStore.setValueAtPath('myNumber', 42, true)
     })
     expect(getByTestId('value').textContent).toBe('42')
 
-    // Unmount – disposePaths decrements __refCount to 0 but the value stays in the store
-    unmount()
+    act(() => unmount())
 
-    // Clear the cached value so the next mount starts fresh
+    const { getByTestId: getByTestId2 } = render(<NumberComponentClearOnUnmount id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+  })
+
+  it('clearOnUnmount option resets the value on remount', () => {
+    const { getByTestId, unmount } = render(<ClearOnUnmountOptionComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    act(() => unmount())
+
+    const { getByTestId: getByTestId2 } = render(<ClearOnUnmountOptionComponent id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+  })
+
+  it('resets to the initial value when remounted after clearPath', () => {
+    const { getByTestId, unmount } = render(<NumberComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    unmount()
     levaStore.clearPath('myNumber')
 
-    // Remount – useControls reads from the schema (value: 5) because the path is gone
     const { getByTestId: getByTestId2 } = render(<NumberComponent id="value2" />)
     expect(getByTestId2('value2').textContent).toBe('5')
   })

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -26,6 +26,7 @@ import { levaStore } from './store'
 
 afterEach(() => {
   levaStore.dispose()
+  levaStore.setClearOnUnmount(false)
 })
 
 function NumberComponent({ id }: { id?: string }) {
@@ -120,6 +121,23 @@ describe('useControls mount/unmount lifecycle', () => {
     act(() => unmount())
 
     const { getByTestId: getByTestId2 } = render(<ClearOnUnmountOptionComponent id="value2" />)
+    expect(getByTestId2('value2').textContent).toBe('5')
+  })
+
+  it('store-level clearOnUnmount resets all inputs on remount', () => {
+    levaStore.setClearOnUnmount(true)
+
+    const { getByTestId, unmount } = render(<NumberComponent id="value" />)
+    expect(getByTestId('value').textContent).toBe('5')
+
+    act(() => {
+      levaStore.setValueAtPath('myNumber', 42, true)
+    })
+    expect(getByTestId('value').textContent).toBe('42')
+
+    act(() => unmount())
+
+    const { getByTestId: getByTestId2 } = render(<NumberComponent id="value2" />)
     expect(getByTestId2('value2').textContent).toBe('5')
   })
 

--- a/packages/leva/src/useControls.test.tsx
+++ b/packages/leva/src/useControls.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@stitches/react', () => ({
 
 afterEach(() => {
   levaStore.dispose()
-  levaStore.setClearOnUnmount(false)
+  levaStore.setNoCache(false)
 })
 
 function NumberComponent({ id }: { id?: string }) {
@@ -41,7 +41,7 @@ function NestedNumberComponent({ id }: { id?: string }) {
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 
-function NumberComponentClearOnUnmount({ id }: { id?: string }) {
+function NumberComponentNoCache({ id }: { id?: string }) {
   const { myNumber } = useControls({ myNumber: 5 }, { headless: true })
   useEffect(
     () => () => {
@@ -52,8 +52,8 @@ function NumberComponentClearOnUnmount({ id }: { id?: string }) {
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 
-function ClearOnUnmountOptionComponent({ id }: { id?: string }) {
-  const { myNumber } = useControls({ myNumber: { value: 5, clearOnUnmount: true } }, { headless: true })
+function NoCacheOptionComponent({ id }: { id?: string }) {
+  const { myNumber } = useControls({ myNumber: { value: 5, noCache: true } }, { headless: true })
   return <div data-testid={id ?? 'value'}>{myNumber}</div>
 }
 
@@ -102,7 +102,7 @@ describe('useControls mount/unmount lifecycle', () => {
   })
 
   it('useEffect clearPath resets the value on remount', () => {
-    const { getByTestId, unmount } = render(<NumberComponentClearOnUnmount id="value" />)
+    const { getByTestId, unmount } = render(<NumberComponentNoCache id="value" />)
     expect(getByTestId('value').textContent).toBe('5')
 
     act(() => {
@@ -112,12 +112,12 @@ describe('useControls mount/unmount lifecycle', () => {
 
     act(() => unmount())
 
-    const { getByTestId: getByTestId2 } = render(<NumberComponentClearOnUnmount id="value2" />)
+    const { getByTestId: getByTestId2 } = render(<NumberComponentNoCache id="value2" />)
     expect(getByTestId2('value2').textContent).toBe('5')
   })
 
-  it('clearOnUnmount option resets the value on remount', () => {
-    const { getByTestId, unmount } = render(<ClearOnUnmountOptionComponent id="value" />)
+  it('noCache option resets the value on remount', () => {
+    const { getByTestId, unmount } = render(<NoCacheOptionComponent id="value" />)
     expect(getByTestId('value').textContent).toBe('5')
 
     act(() => {
@@ -127,12 +127,12 @@ describe('useControls mount/unmount lifecycle', () => {
 
     act(() => unmount())
 
-    const { getByTestId: getByTestId2 } = render(<ClearOnUnmountOptionComponent id="value2" />)
+    const { getByTestId: getByTestId2 } = render(<NoCacheOptionComponent id="value2" />)
     expect(getByTestId2('value2').textContent).toBe('5')
   })
 
-  it('store-level clearOnUnmount resets all inputs on remount', () => {
-    levaStore.setClearOnUnmount(true)
+  it('store-level noCache resets all inputs on remount', () => {
+    levaStore.setNoCache(true)
 
     const { getByTestId, unmount } = render(<NumberComponent id="value" />)
     expect(getByTestId('value').textContent).toBe('5')
@@ -148,12 +148,12 @@ describe('useControls mount/unmount lifecycle', () => {
     expect(getByTestId2('value2').textContent).toBe('5')
   })
 
-  it('LevaPanel clearOnUnmount prop wires to store and resets inputs on remount', () => {
+  it('LevaPanel noCache prop wires to store and resets inputs on remount', () => {
     // LevaPanel and the consuming component are rendered in separate trees so
     // that unmounting the component doesn't also unmount LevaPanel (which would
-    // trigger the cleanup that resets clearOnUnmount to false before the
+    // trigger the cleanup that resets noCache to false before the
     // component's own cleanup can call clearPath).
-    const { unmount: unmountPanel } = render(<LevaPanel store={levaStore} clearOnUnmount />)
+    const { unmount: unmountPanel } = render(<LevaPanel store={levaStore} noCache />)
 
     const { getByTestId, unmount: unmountComponent } = render(<NumberComponent id="value" />)
     expect(getByTestId('value').textContent).toBe('5')

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -133,14 +133,15 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
    * parses the schema inside nested folder.
    */
   const [initialData, mappedPaths] = useMemo(() => store.getDataFromSchema(_schema), [store, _schema])
-  const [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths] = useMemo(() => {
+  const [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, clearOnUnmountPaths] = useMemo(() => {
     const allPaths: string[] = []
     const renderPaths: string[] = []
     const onChangePaths: Record<string, OnChangeHandler> = {}
     const onEditStartPaths: Record<string, (...args: any) => void> = {}
     const onEditEndPaths: Record<string, (...args: any) => void> = {}
+    const clearOnUnmountPaths = new Set<string>()
 
-    Object.values(mappedPaths).forEach(({ path, onChange, onEditStart, onEditEnd, transient }) => {
+    Object.values(mappedPaths).forEach(({ path, onChange, onEditStart, onEditEnd, transient, clearOnUnmount }) => {
       allPaths.push(path)
       if (onChange) {
         onChangePaths[path] = onChange
@@ -157,8 +158,13 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
       if (onEditEnd) {
         onEditEndPaths[path] = onEditEnd
       }
+      if (clearOnUnmount) {
+        clearOnUnmountPaths.add(path)
+      } else {
+        clearOnUnmountPaths.delete(path)
+      }
     })
-    return [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths]
+    return [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, clearOnUnmountPaths]
   }, [mappedPaths])
 
   // Extracts the paths from the initialData and ensures order of paths.
@@ -199,8 +205,11 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     store.addData(initialData, shouldOverrideSettings)
     firstRender.current = false
     depsChanged.current = false
-    return () => store.disposePaths(paths)
-  }, [store, paths, initialData])
+    return () => {
+      store.disposePaths(paths)
+      clearOnUnmountPaths.forEach((path) => store.clearPath(path))
+    }
+  }, [store, paths, initialData, clearOnUnmountPaths])
 
   useEffect(() => {
     // let's handle transient subscriptions

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -207,7 +207,8 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     depsChanged.current = false
     return () => {
       store.disposePaths(paths)
-      clearOnUnmountPaths.forEach((path) => store.clearPath(path))
+      const pathsToClear = store.clearOnUnmount ? paths : [...clearOnUnmountPaths]
+      pathsToClear.forEach((path) => store.clearPath(path))
     }
   }, [store, paths, initialData, clearOnUnmountPaths])
 

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -160,8 +160,6 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
       }
       if (noCache) {
         noCachePaths.add(path)
-      } else {
-        noCachePaths.delete(path)
       }
     })
     return [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, noCachePaths]
@@ -208,7 +206,9 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     return () => {
       store.disposePaths(paths)
       const pathsToClear = store.noCache ? paths : [...noCachePaths]
-      pathsToClear.forEach((path) => store.clearPath(path))
+      for (const path of pathsToClear) {
+        store.clearPath(path)
+      }
     }
   }, [store, paths, initialData, noCachePaths])
 

--- a/packages/leva/src/useControls.ts
+++ b/packages/leva/src/useControls.ts
@@ -133,15 +133,15 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
    * parses the schema inside nested folder.
    */
   const [initialData, mappedPaths] = useMemo(() => store.getDataFromSchema(_schema), [store, _schema])
-  const [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, clearOnUnmountPaths] = useMemo(() => {
+  const [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, noCachePaths] = useMemo(() => {
     const allPaths: string[] = []
     const renderPaths: string[] = []
     const onChangePaths: Record<string, OnChangeHandler> = {}
     const onEditStartPaths: Record<string, (...args: any) => void> = {}
     const onEditEndPaths: Record<string, (...args: any) => void> = {}
-    const clearOnUnmountPaths = new Set<string>()
+    const noCachePaths = new Set<string>()
 
-    Object.values(mappedPaths).forEach(({ path, onChange, onEditStart, onEditEnd, transient, clearOnUnmount }) => {
+    Object.values(mappedPaths).forEach(({ path, onChange, onEditStart, onEditEnd, transient, noCache }) => {
       allPaths.push(path)
       if (onChange) {
         onChangePaths[path] = onChange
@@ -158,13 +158,13 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
       if (onEditEnd) {
         onEditEndPaths[path] = onEditEnd
       }
-      if (clearOnUnmount) {
-        clearOnUnmountPaths.add(path)
+      if (noCache) {
+        noCachePaths.add(path)
       } else {
-        clearOnUnmountPaths.delete(path)
+        noCachePaths.delete(path)
       }
     })
-    return [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, clearOnUnmountPaths]
+    return [allPaths, renderPaths, onChangePaths, onEditStartPaths, onEditEndPaths, noCachePaths]
   }, [mappedPaths])
 
   // Extracts the paths from the initialData and ensures order of paths.
@@ -207,10 +207,10 @@ export function useControls<S extends Schema, F extends SchemaOrFn<S> | string, 
     depsChanged.current = false
     return () => {
       store.disposePaths(paths)
-      const pathsToClear = store.clearOnUnmount ? paths : [...clearOnUnmountPaths]
+      const pathsToClear = store.noCache ? paths : [...noCachePaths]
       pathsToClear.forEach((path) => store.clearPath(path))
     }
-  }, [store, paths, initialData, clearOnUnmountPaths])
+  }, [store, paths, initialData, noCachePaths])
 
   useEffect(() => {
     // let's handle transient subscriptions

--- a/packages/leva/src/utils/data.ts
+++ b/packages/leva/src/utils/data.ts
@@ -65,7 +65,7 @@ export function getDataFromSchema(
       if (normalizedInput) {
         const { type, options, input } = normalizedInput
         // @ts-ignore
-        const { onChange, transient, onEditStart, onEditEnd, clearOnUnmount, ..._options } = options
+        const { onChange, transient, onEditStart, onEditEnd, noCache, ..._options } = options
         data[newPath] = { type, ..._options, ...input, fromPanel: true }
         mappedPaths[key] = {
           path: newPath,
@@ -73,7 +73,7 @@ export function getDataFromSchema(
           transient,
           onEditStart,
           onEditEnd,
-          clearOnUnmount: clearOnUnmount ?? false,
+          noCache: noCache ?? false,
         }
       } else {
         warn(LevaErrors.UNKNOWN_INPUT, newPath, rawInput)

--- a/packages/leva/src/utils/data.ts
+++ b/packages/leva/src/utils/data.ts
@@ -65,9 +65,9 @@ export function getDataFromSchema(
       if (normalizedInput) {
         const { type, options, input } = normalizedInput
         // @ts-ignore
-        const { onChange, transient, onEditStart, onEditEnd, ..._options } = options
+        const { onChange, transient, onEditStart, onEditEnd, clearOnUnmount, ..._options } = options
         data[newPath] = { type, ..._options, ...input, fromPanel: true }
-        mappedPaths[key] = { path: newPath, onChange, transient, onEditStart, onEditEnd }
+        mappedPaths[key] = { path: newPath, onChange, transient, onEditStart, onEditEnd, clearOnUnmount: clearOnUnmount ?? false }
       } else {
         warn(LevaErrors.UNKNOWN_INPUT, newPath, rawInput)
       }

--- a/packages/leva/src/utils/data.ts
+++ b/packages/leva/src/utils/data.ts
@@ -67,7 +67,14 @@ export function getDataFromSchema(
         // @ts-ignore
         const { onChange, transient, onEditStart, onEditEnd, clearOnUnmount, ..._options } = options
         data[newPath] = { type, ..._options, ...input, fromPanel: true }
-        mappedPaths[key] = { path: newPath, onChange, transient, onEditStart, onEditEnd, clearOnUnmount: clearOnUnmount ?? false }
+        mappedPaths[key] = {
+          path: newPath,
+          onChange,
+          transient,
+          onEditStart,
+          onEditEnd,
+          clearOnUnmount: clearOnUnmount ?? false,
+        }
       } else {
         warn(LevaErrors.UNKNOWN_INPUT, newPath, rawInput)
       }

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -65,7 +65,7 @@ export function parseOptions(
     onEditStart,
     onEditEnd,
     transient,
-    clearOnUnmount,
+    noCache,
     ...inputWithType
   } = _input
 
@@ -80,7 +80,7 @@ export function parseOptions(
     disabled,
     optional,
     order,
-    clearOnUnmount,
+    noCache,
     ...mergedOptions,
   }
 

--- a/packages/leva/src/utils/input.ts
+++ b/packages/leva/src/utils/input.ts
@@ -65,6 +65,7 @@ export function parseOptions(
     onEditStart,
     onEditEnd,
     transient,
+    clearOnUnmount,
     ...inputWithType
   } = _input
 
@@ -79,6 +80,7 @@ export function parseOptions(
     disabled,
     optional,
     order,
+    clearOnUnmount,
     ...mergedOptions,
   }
 

--- a/packages/leva/stories/clear-on-unmount.stories.tsx
+++ b/packages/leva/stories/clear-on-unmount.stories.tsx
@@ -134,18 +134,24 @@ PanelOverridesPerInput.storyName = 'panel noCache overrides per-input'
 // store.clearPath — custom store, imperative usage
 // ---------------------------------------------------------------------------
 
+const ClearPathControls = ({ store }: { store: ReturnType<typeof useCreateStore> }) => {
+  const values = useControls({ position: { x: 0, y: 0 }, speed: 1 }, { store })
+  return <pre>{JSON.stringify(values, null, '  ')}</pre>
+}
+
 /**
  * `store.clearPath(path)` lets you imperatively discard the cached value of a
  * single input. This is useful when you manage your own store and want fine-
  * grained control over cache invalidation without unmounting the component.
  *
- * Click "Clear position cache" — the next time the component remounts it will
- * start from the initial value again.
+ * 1. Change `position` in the panel.
+ * 2. Click "Unmount controls" — the component unmounts but the cache is preserved.
+ * 3. Click "Clear position cache" — discards the cached value.
+ * 4. Click "Mount controls" — position restarts from `{ x: 0, y: 0 }`.
  */
 export const ClearPath: StoryFn = () => {
   const store = useCreateStore()
-
-  const values = useControls({ position: { x: 0, y: 0 }, speed: 1 }, { store })
+  const [mounted, setMounted] = React.useState(true)
 
   return (
     <div>
@@ -154,15 +160,17 @@ export const ClearPath: StoryFn = () => {
         <p>
           <strong>store.clearPath</strong> imperatively discards a single cached input.
         </p>
-        <pre>{JSON.stringify(values, null, '  ')}</pre>
+        {mounted && <ClearPathControls store={store} />}
       </div>
-      <button
-        onClick={() => {
-          // Discard the cached position; next mount will use the initial value.
-          store.clearPath('position')
-        }}>
-        Clear position cache
-      </button>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button onClick={() => setMounted((m) => !m)}>{mounted ? 'Unmount controls' : 'Mount controls'}</button>
+        <button
+          onClick={() => {
+            store.clearPath('position')
+          }}>
+          Clear position cache
+        </button>
+      </div>
     </div>
   )
 }

--- a/packages/leva/stories/clear-on-unmount.stories.tsx
+++ b/packages/leva/stories/clear-on-unmount.stories.tsx
@@ -10,13 +10,13 @@ export default {
 } as Meta
 
 // ---------------------------------------------------------------------------
-// Per-input clearOnUnmount
+// Per-input noCache
 // ---------------------------------------------------------------------------
 
 const PerInputControls = () => {
   const values = useControls({
     persistent: { value: 10 },
-    clearable: { value: 42, clearOnUnmount: true },
+    clearable: { value: 42, noCache: true },
   })
 
   return (
@@ -33,7 +33,7 @@ const PerInputControls = () => {
 }
 
 /**
- * Only the input marked with `clearOnUnmount: true` resets when the component
+ * Only the input marked with `noCache: true` resets when the component
  * unmounts. The other input retains its value.
  *
  * Steps to verify:
@@ -52,10 +52,10 @@ export const PerInput: StoryFn = () => {
   )
 }
 
-PerInput.storyName = 'clearOnUnmount (per-input)'
+PerInput.storyName = 'noCache (per-input)'
 
 // ---------------------------------------------------------------------------
-// Panel-level clearOnUnmount via <Leva clearOnUnmount>
+// Panel-level noCache via <Leva noCache>
 // ---------------------------------------------------------------------------
 
 const PanelLevelControls = () => {
@@ -63,16 +63,16 @@ const PanelLevelControls = () => {
 
   return (
     <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
-      <p>All inputs clear on unmount because the panel has clearOnUnmount.</p>
+      <p>All inputs clear on unmount because the panel has noCache.</p>
       <pre>{JSON.stringify(values, null, '  ')}</pre>
     </div>
   )
 }
 
 /**
- * When `<Leva clearOnUnmount>` is set, ALL inputs managed by the default panel
+ * When `<Leva noCache>` is set, ALL inputs managed by the default panel
  * have their cached values discarded when they unmount, regardless of the
- * per-input `clearOnUnmount` setting.
+ * per-input `noCache` setting.
  *
  * Steps to verify:
  * 1. Change `num` and `color` in the panel.
@@ -84,36 +84,36 @@ export const PanelLevel: StoryFn = () => {
 
   return (
     <div>
-      <Leva clearOnUnmount />
+      <Leva noCache />
       <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
       {mounted && <PanelLevelControls />}
     </div>
   )
 }
 
-PanelLevel.storyName = 'clearOnUnmount (panel-level)'
+PanelLevel.storyName = 'noCache (panel-level)'
 
 // ---------------------------------------------------------------------------
-// Panel-level clearOnUnmount overrides per-input false
+// Panel-level noCache overrides per-input false
 // ---------------------------------------------------------------------------
 
 const MixedControls = () => {
   const values = useControls({
     willClear: { value: 99 },
-    alsoWillClear: { value: '#0f0', clearOnUnmount: false },
+    alsoWillClear: { value: '#0f0', noCache: false },
   })
 
   return (
     <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
-      <p>Panel-level clearOnUnmount overrides per-input clearOnUnmount: false.</p>
+      <p>Panel-level noCache overrides per-input noCache: false.</p>
       <pre>{JSON.stringify(values, null, '  ')}</pre>
     </div>
   )
 }
 
 /**
- * Panel-level `clearOnUnmount` takes priority over the per-input setting.
- * Even `alsoWillClear` (which sets `clearOnUnmount: false`) will be cleared
+ * Panel-level `noCache` takes priority over the per-input setting.
+ * Even `alsoWillClear` (which sets `noCache: false`) will be cleared
  * because the panel flag overrides it.
  */
 export const PanelOverridesPerInput: StoryFn = () => {
@@ -121,14 +121,14 @@ export const PanelOverridesPerInput: StoryFn = () => {
 
   return (
     <div>
-      <Leva clearOnUnmount />
+      <Leva noCache />
       <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
       {mounted && <MixedControls />}
     </div>
   )
 }
 
-PanelOverridesPerInput.storyName = 'panel clearOnUnmount overrides per-input'
+PanelOverridesPerInput.storyName = 'panel noCache overrides per-input'
 
 // ---------------------------------------------------------------------------
 // store.clearPath — custom store, imperative usage

--- a/packages/leva/stories/clear-on-unmount.stories.tsx
+++ b/packages/leva/stories/clear-on-unmount.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import Reset from './components/decorator-reset'
+
+import { Leva, useControls, useCreateStore, LevaPanel } from '../src'
+
+export default {
+  title: 'Dev/Hook/Clear on Unmount',
+  decorators: [Reset],
+} as Meta
+
+// ---------------------------------------------------------------------------
+// Per-input clearOnUnmount
+// ---------------------------------------------------------------------------
+
+const PerInputControls = () => {
+  const values = useControls({
+    persistent: { value: 10 },
+    clearable: { value: 42, clearOnUnmount: true },
+  })
+
+  return (
+    <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
+      <p>
+        <strong>persistent</strong> keeps its value across unmount/remount
+      </p>
+      <p>
+        <strong>clearable</strong> resets to its initial value after unmount
+      </p>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
+}
+
+/**
+ * Only the input marked with `clearOnUnmount: true` resets when the component
+ * unmounts. The other input retains its value.
+ *
+ * Steps to verify:
+ * 1. Change both `persistent` and `clearable` in the panel.
+ * 2. Click "Unmount" then "Mount".
+ * 3. `persistent` should show the last value you set; `clearable` should be back to 42.
+ */
+export const PerInput: StoryFn = () => {
+  const [mounted, toggle] = React.useState(true)
+
+  return (
+    <div>
+      <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
+      {mounted && <PerInputControls />}
+    </div>
+  )
+}
+
+PerInput.storyName = 'clearOnUnmount (per-input)'
+
+// ---------------------------------------------------------------------------
+// Panel-level clearOnUnmount via <Leva clearOnUnmount>
+// ---------------------------------------------------------------------------
+
+const PanelLevelControls = () => {
+  const values = useControls({ num: 5, color: '#f00' })
+
+  return (
+    <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
+      <p>All inputs clear on unmount because the panel has clearOnUnmount.</p>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
+}
+
+/**
+ * When `<Leva clearOnUnmount>` is set, ALL inputs managed by the default panel
+ * have their cached values discarded when they unmount, regardless of the
+ * per-input `clearOnUnmount` setting.
+ *
+ * Steps to verify:
+ * 1. Change `num` and `color` in the panel.
+ * 2. Click "Unmount" then "Mount".
+ * 3. Both values should be back to their initial defaults.
+ */
+export const PanelLevel: StoryFn = () => {
+  const [mounted, toggle] = React.useState(true)
+
+  return (
+    <div>
+      <Leva clearOnUnmount />
+      <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
+      {mounted && <PanelLevelControls />}
+    </div>
+  )
+}
+
+PanelLevel.storyName = 'clearOnUnmount (panel-level)'
+
+// ---------------------------------------------------------------------------
+// Panel-level clearOnUnmount overrides per-input false
+// ---------------------------------------------------------------------------
+
+const MixedControls = () => {
+  const values = useControls({
+    willClear: { value: 99 },
+    alsoWillClear: { value: '#0f0', clearOnUnmount: false },
+  })
+
+  return (
+    <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
+      <p>Panel-level clearOnUnmount overrides per-input clearOnUnmount: false.</p>
+      <pre>{JSON.stringify(values, null, '  ')}</pre>
+    </div>
+  )
+}
+
+/**
+ * Panel-level `clearOnUnmount` takes priority over the per-input setting.
+ * Even `alsoWillClear` (which sets `clearOnUnmount: false`) will be cleared
+ * because the panel flag overrides it.
+ */
+export const PanelOverridesPerInput: StoryFn = () => {
+  const [mounted, toggle] = React.useState(true)
+
+  return (
+    <div>
+      <Leva clearOnUnmount />
+      <button onClick={() => toggle((t) => !t)}>{mounted ? 'Unmount' : 'Mount'}</button>
+      {mounted && <MixedControls />}
+    </div>
+  )
+}
+
+PanelOverridesPerInput.storyName = 'panel clearOnUnmount overrides per-input'
+
+// ---------------------------------------------------------------------------
+// store.clearPath — custom store, imperative usage
+// ---------------------------------------------------------------------------
+
+/**
+ * `store.clearPath(path)` lets you imperatively discard the cached value of a
+ * single input. This is useful when you manage your own store and want fine-
+ * grained control over cache invalidation without unmounting the component.
+ *
+ * Click "Clear position cache" — the next time the component remounts it will
+ * start from the initial value again.
+ */
+export const ClearPath: StoryFn = () => {
+  const store = useCreateStore()
+
+  const values = useControls({ position: { x: 0, y: 0 }, speed: 1 }, { store })
+
+  return (
+    <div>
+      <LevaPanel store={store} />
+      <div style={{ padding: 20, border: '1px solid #444', margin: '10px 0' }}>
+        <p>
+          <strong>store.clearPath</strong> imperatively discards a single cached input.
+        </p>
+        <pre>{JSON.stringify(values, null, '  ')}</pre>
+      </div>
+      <button
+        onClick={() => {
+          // Discard the cached position; next mount will use the initial value.
+          store.clearPath('position')
+        }}>
+        Clear position cache
+      </button>
+    </div>
+  )
+}
+
+ClearPath.storyName = 'store.clearPath (imperative)'

--- a/packages/plugin-plot/src/plot-plugin.ts
+++ b/packages/plugin-plot/src/plot-plugin.ts
@@ -1,4 +1,4 @@
-import type { Data } from 'packages/leva/src/types'
+import type { Data, StoreType } from 'packages/leva/src/types'
 import * as math from 'mathjs'
 import { parseExpression } from './plot-utils'
 import type { PlotInput, InternalPlot, InternalPlotSettings } from './plot-types'
@@ -8,7 +8,7 @@ export const sanitize = (
   _settings: InternalPlotSettings,
   _prevValue: math.MathNode,
   _path: string,
-  store: { get: (path: string) => any }
+  store: StoreType
 ) => {
   if (expression === '') throw Error('Empty mathjs expression')
   try {

--- a/packages/plugin-plot/src/plot-plugin.ts
+++ b/packages/plugin-plot/src/plot-plugin.ts
@@ -1,4 +1,4 @@
-import type { Data, StoreType } from 'leva/plugin'
+import type { Data } from 'packages/leva/src/types'
 import * as math from 'mathjs'
 import { parseExpression } from './plot-utils'
 import type { PlotInput, InternalPlot, InternalPlotSettings } from './plot-types'
@@ -8,7 +8,7 @@ export const sanitize = (
   _settings: InternalPlotSettings,
   _prevValue: math.MathNode,
   _path: string,
-  store: StoreType
+  store: { get: (path: string) => any }
 ) => {
   if (expression === '') throw Error('Empty mathjs expression')
   try {

--- a/packages/plugin-plot/src/plot-plugin.ts
+++ b/packages/plugin-plot/src/plot-plugin.ts
@@ -1,4 +1,4 @@
-import { Data, StoreType } from 'packages/leva/src/types'
+import type { Data, StoreType } from 'leva/plugin'
 import * as math from 'mathjs'
 import { parseExpression } from './plot-utils'
 import type { PlotInput, InternalPlot, InternalPlotSettings } from './plot-types'


### PR DESCRIPTION
## Summary

- Adds `store.clearPath(path)` — new method to imperatively discard the cached value of an input that is no longer mounted
- Adds `noCache` to `InputOptions` — per-input flag; when `true` the input's cached value is discarded from the store on unmount
- Adds `noCache` to `LevaRootProps` — panel-level flag; when `true` all inputs managed by that panel have their cached values discarded on unmount, overriding the per-input setting
- Added unit tests and storybook examples and updated docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `noCache` option to automatically clear individual input values from cache on unmount.
  * Added `noCache` prop to panels to clear all cached values on unmount.
  * Added `store.clearPath()` method for imperatively removing specific cached values.

* **Documentation**
  * Added guide showing three methods for clearing cached input values with usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->