### PR TITLE
fix: update string input value in real-time

### DIFF
--- a/.changeset/plenty-spies-provide.md
+++ b/.changeset/plenty-spies-provide.md
@@ -1,0 +1,5 @@
+---
+"leva": patch
+---
+
+fix: update string input value in real-time

--- a/packages/leva/src/components/ValueInput/ValueInput.tsx
+++ b/packages/leva/src/components/ValueInput/ValueInput.tsx
@@ -13,6 +13,7 @@ export type ValueInputProps = {
   onChange: (value: string) => void
   onKeyDown?: (event: React.KeyboardEvent) => void
   rows?: number
+  liveUpdate?: boolean
 }
 
 export function ValueInput({
@@ -25,6 +26,7 @@ export function ValueInput({
   id,
   inputType = 'text',
   rows = 0,
+  liveUpdate = false,
   ...props
 }: ValueInputProps) {
   const { id: _id, emitOnEditStart, emitOnEditEnd, disabled } = useInputContext()
@@ -86,9 +88,7 @@ export function ValueInput({
         value={value}
         onChange={update((value) => {
           onChange(value)
-          // Only call onUpdate for non-number inputs; number inputs retain
-          // their original commit behavior (on blur/Enter via dragEnd)
-          if (type !== "number") onUpdate(value)
+          if (type !== "number" || liveUpdate) onUpdate(value)
         })}
         onFocus={() => emitOnEditStart()}
         onKeyPress={onKeyPress}

--- a/packages/leva/src/components/ValueInput/ValueInput.tsx
+++ b/packages/leva/src/components/ValueInput/ValueInput.tsx
@@ -84,7 +84,12 @@ export function ValueInput({
         autoComplete="off"
         spellCheck="false"
         value={value}
-        onChange={update(onChange)}
+        onChange={update((value) => {
+          onChange(value)
+          // Only call onUpdate for non-number inputs; number inputs retain
+          // their original commit behavior (on blur/Enter via dragEnd)
+          if (type !== "number") onUpdate(value)
+        })}
         onFocus={() => emitOnEditStart()}
         onKeyPress={onKeyPress}
         onKeyDown={onKeyDown}

--- a/packages/leva/src/plugins/String/String.tsx
+++ b/packages/leva/src/plugins/String/String.tsx
@@ -13,7 +13,7 @@ const NonEditableString = styled('div', {
 })
 
 export function String({ displayValue, onUpdate, onChange, editable = true, ...props }: BaseStringProps) {
-  if (editable) return <ValueInput value={displayValue} onUpdate={onUpdate} onChange={onChange} {...props} />
+  if (editable) return <ValueInput value={displayValue} onUpdate={onUpdate} onChange={onChange} liveUpdate {...props} />
   return <NonEditableString>{displayValue}</NonEditableString>
 }
 


### PR DESCRIPTION
## Summary

Previously, string inputs in Leva only committed changes to the store when the input lost focus (on blur). This meant that `useEffect` hooks depending on the value would only fire after clicking away from the input.

This fix makes `onUpdate` fire on every keystroke, so the store value updates in real-time.

## Changes

- Modified `ValueInput.tsx` to call both `onChange` and `onUpdate` on every `onChange` event
- This affects both text inputs and textareas

## Testing

Build passes successfully. The change maintains backward compatibility - `onUpdate` was already being called on blur, and now it's also called on every keystroke.

Fixes #599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * String/text inputs now propagate changes in real time as you type when editable, ensuring external listeners and UI reflect edits immediately; numeric inputs still commit on blur/Enter to preserve existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->