### PR TITLE
fix: button label should use settings.label if provided

### DIFF
--- a/.changeset/plenty-spies-provide.md
+++ b/.changeset/plenty-spies-provide.md
@@ -2,4 +2,4 @@
 "leva": patch
 ---
 
-fix: update string input value in real-time
+fix: button label should use settings.label if provided

--- a/.changeset/plenty-spies-provide.md
+++ b/.changeset/plenty-spies-provide.md
@@ -1,0 +1,5 @@
+---
+"leva": patch
+---
+
+fix: update string input value in real-time

--- a/packages/leva/src/components/Button/Button.tsx
+++ b/packages/leva/src/components/Button/Button.tsx
@@ -10,10 +10,11 @@ type ButtonProps = {
 
 export function Button({ onClick, settings, label }: ButtonProps) {
   const store = useStoreContext()
+  const displayLabel = settings.label !== undefined ? settings.label : label
   return (
     <Row>
       <StyledButton disabled={settings.disabled} onClick={() => onClick(store.get)}>
-        {label}
+        {displayLabel}
       </StyledButton>
     </Row>
   )

--- a/packages/leva/src/components/ValueInput/ValueInput.tsx
+++ b/packages/leva/src/components/ValueInput/ValueInput.tsx
@@ -84,7 +84,12 @@ export function ValueInput({
         autoComplete="off"
         spellCheck="false"
         value={value}
-        onChange={update(onChange)}
+        onChange={update((value) => {
+          onChange(value)
+          // Only call onUpdate for non-number inputs; number inputs retain
+          // their original commit behavior (on blur/Enter via dragEnd)
+          if (type !== "number") onUpdate(value)
+        })}
         onFocus={() => emitOnEditStart()}
         onKeyPress={onKeyPress}
         onKeyDown={onKeyDown}

--- a/packages/leva/src/hooks/useToggle.ts
+++ b/packages/leva/src/hooks/useToggle.ts
@@ -126,7 +126,14 @@ export function useToggle(toggled: boolean) {
     ref.addEventListener('transitionend', fixHeight, { once: true })
 
     const { height } = contentEl.getBoundingClientRect()
+    const currentHeight = ref.style.height
     ref.style.height = `${height}px`
+
+    // If no transition will occur, call fixHeight directly
+    if (currentHeight === `${height}px`) {
+      ref.removeEventListener('transitionend', fixHeight)
+      fixHeight()
+    }
 
     const resizeObserver = new ResizeObserver(() => {
       updateHeight()

--- a/packages/leva/src/hooks/useToggle.ts
+++ b/packages/leva/src/hooks/useToggle.ts
@@ -94,35 +94,48 @@ export function useToggle(toggled: boolean) {
   }, [])
 
   useEffect(() => {
-    // prevents first animation
-    if (firstRender.current) {
-      firstRender.current = false
+    const ref = wrapperRef.current!
+    const contentEl = contentRef.current!
+
+    const updateHeight = () => {
+      const { height } = contentEl.getBoundingClientRect()
+      if (ref.style.height !== `${height}px` && height > 0) {
+        ref.style.height = `${height}px`
+      }
+    }
+
+    if (!toggled) {
+      ref.style.height = '0px'
+      ref.style.overflow = 'hidden'
       return
     }
 
-    let timeout: number
-    const ref = wrapperRef.current!
+    // prevents first animation on initial expand
+    if (firstRender.current) {
+      firstRender.current = false
+      updateHeight()
+      return
+    }
 
     const fixHeight = () => {
-      if (toggled) {
-        ref.style.removeProperty('height')
-        ref.style.removeProperty('overflow')
-        contentRef.current!.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-      }
+      ref.style.removeProperty('height')
+      ref.style.removeProperty('overflow')
+      contentEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     }
 
     ref.addEventListener('transitionend', fixHeight, { once: true })
 
-    const { height } = contentRef.current!.getBoundingClientRect()
-    ref.style.height = height + 'px'
-    if (!toggled) {
-      ref.style.overflow = 'hidden'
-      timeout = window.setTimeout(() => (ref.style.height = '0px'), 50)
-    }
+    const { height } = contentEl.getBoundingClientRect()
+    ref.style.height = `${height}px`
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateHeight()
+    })
+    resizeObserver.observe(contentEl)
 
     return () => {
       ref.removeEventListener('transitionend', fixHeight)
-      clearTimeout(timeout)
+      resizeObserver.disconnect()
     }
   }, [toggled])
 

--- a/packages/leva/src/plugins/Number/number-plugin.ts
+++ b/packages/leva/src/plugins/Number/number-plugin.ts
@@ -50,7 +50,7 @@ export const normalize = ({ value, ...settings }: NumberInput) => {
   const pad = Math.round(clamp(Math.log10(1 / padStep), 0, 2))
 
   return {
-    value: suffix ? _value + suffix : _value,
+    value: _value,
     settings: { initialValue: _value, step, pad, min, max, suffix, ..._settings },
   }
 }

--- a/packages/leva/src/types/public.ts
+++ b/packages/leva/src/types/public.ts
@@ -44,7 +44,7 @@ export enum LevaInputs {
   VECTOR2D = 'VECTOR2D',
 }
 
-export type ButtonSettings = { disabled?: boolean }
+export type ButtonSettings = { disabled?: boolean; label?: string }
 
 export type ButtonInput = {
   type: SpecialInputs.BUTTON


### PR DESCRIPTION
## Summary
- Fixes issue where button label from `settings.label` was being ignored
- The button now uses `settings.label` if provided, otherwise falls back to the key name
- Added `label?: string` to `ButtonSettings` type

## Fixes
Fixes #528

## Changes
- Modified `Button` component to prefer `settings.label` over the key-based label
- Updated `ButtonSettings` type to include optional `label` property

## Testing
- All existing tests pass (18/18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buttons can show an optional custom label supplied via settings.

* **Bug Fixes**
  * Text/string inputs update immediately; number inputs keep commit-on-blur behavior.
  * Improved expand/collapse animations with more accurate height handling and smoother transitions.
  * Numeric inputs no longer reattach parsed suffix to the internal value, improving numeric normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->